### PR TITLE
Demonstrable search and find Slack slash commands integrated with strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The default username is in env config but please set the password in env;
 Windows -> set SEARCH_STRAPI_PASSWORD=xxxxx
 Linux -> export set SEARCH_STRAPI_PASSWORD=xxxxx
 
+export set FIND_SLACK_TOKEN=xoxp-xxxxxxxxxxx
+
 ## From Postman, Curl and other Test Clients
 
 The Slack message is a POST of type application/x-www-form-urlencoded.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ The default username is in env config but please set the password in env;
 Windows -> set SEARCH_STRAPI_PASSWORD=xxxxx
 Linux -> export set SEARCH_STRAPI_PASSWORD=xxxxx
 
+## From Postman, Curl and other Test Clients
+
+The Slack message is a POST of type application/x-www-form-urlencoded.
+To grab the body to verify the token I had to make changes to the decoding orders.
+NB: sending application/json does not decode correctly.
+
 ## examples
 * `/asc-search postcode SE19`
 * `/asc-search postcode SE19 3SS`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## commands
 * /asc-search [postcode] [nmdsid] [name] [username] <value>
 
+## Config
+The default username is in env config but please set the password in env;
+set SEARCH_STRAPI_PASSWORD=xxxxx
+
 ## examples
 * `/asc-search postcode SE19`
 * `/asc-search postcode SE19 3SS`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 ## Config
 The default username is in env config but please set the password in env;
-set SEARCH_STRAPI_PASSWORD=xxxxx
+
+Windows -> set SEARCH_STRAPI_PASSWORD=xxxxx
+Linux -> export set SEARCH_STRAPI_PASSWORD=xxxxx
 
 ## examples
 * `/asc-search postcode SE19`

--- a/config/config.js
+++ b/config/config.js
@@ -168,6 +168,16 @@ const config = convict({
         format: String,
         default: 'configure_token_here',
         env: 'FIND_SLACK_TOKEN'
+      },
+      slackURL: {
+        doc: 'The URL for Slack Dialog to post back',
+        format: String,
+        default: 'https://slack.com/api/dialog.open',
+      },
+      responseURL: {
+        doc: 'The URL for Slack Dialog to post back',
+        format: String,
+        default: 'http://localhost:3001/find',
       }
     },
     search: {

--- a/config/config.js
+++ b/config/config.js
@@ -163,6 +163,11 @@ const config = convict({
       default: 'http://localhost:3001'
     },
     search: {
+      verifySignature: {
+        doc: 'Weather to verify the Slack Token is signed correctly.',
+        format: 'Boolean',
+        default: true
+      },
       strapiBaseURL: {
         doc: 'The base URL to STRAPI',
         format: 'url',

--- a/config/config.js
+++ b/config/config.js
@@ -162,6 +162,14 @@ const config = convict({
       format: 'url',
       default: 'http://localhost:3001'
     },
+    find: {
+      slackToken: {
+        doc: 'The OAuth Token to login to Slack',
+        format: String,
+        default: 'configure_token_here',
+        env: 'FIND_SLACK_TOKEN'
+      }
+    },
     search: {
       verifySignature: {
         doc: 'Weather to verify the Slack Token is signed correctly.',

--- a/config/config.js
+++ b/config/config.js
@@ -171,12 +171,13 @@ const config = convict({
       strapiUsername: {
         doc: 'The base Username to login to STRAPI',
         format: String,
-        default: 'brianenduser'
+        default: 'configure_username_here'
       },
       strapiPassword: {
         doc: 'The base Password to login to STRAPI',
         format: String,
-        default: 'password'
+        default: 'configure_password_here',
+        env: 'SEARCH_STRAPI_PASSWORD'
       }
     }
   }

--- a/config/config.js
+++ b/config/config.js
@@ -163,6 +163,11 @@ const config = convict({
       default: 'http://localhost:3001'
     },
     find: {
+      verifySignature: {
+        doc: 'Weather to verify the Slack Token is signed correctly.',
+        format: 'Boolean',
+        default: true
+      },
       slackToken: {
         doc: 'The OAuth Token to login to Slack',
         format: String,

--- a/config/localhost.yaml
+++ b/config/localhost.yaml
@@ -14,3 +14,4 @@ app:
     search:
         strapiBaseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:1337
         strapiUsername: brianenduser
+        verifySignature: true

--- a/config/localhost.yaml
+++ b/config/localhost.yaml
@@ -16,4 +16,4 @@ app:
         strapiUsername: brianenduser
         verifySignature: false
     find:
-        responseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:3001/find
+        responseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:3001/actions/search

--- a/config/localhost.yaml
+++ b/config/localhost.yaml
@@ -14,4 +14,4 @@ app:
     search:
         strapiBaseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:1337
         strapiUsername: brianenduser
-        verifySignature: true
+        verifySignature: false

--- a/config/localhost.yaml
+++ b/config/localhost.yaml
@@ -13,4 +13,4 @@ app:
     url: https://sfcdev.cloudapps.digital
     search:
         strapiBaseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:1337
-
+        strapiUsername: brianenduser

--- a/config/localhost.yaml
+++ b/config/localhost.yaml
@@ -15,3 +15,5 @@ app:
         strapiBaseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:1337
         strapiUsername: brianenduser
         verifySignature: false
+    find:
+        responseURL: http://ec2-34-255-118-188.eu-west-1.compute.amazonaws.com:3001/find

--- a/routes/actions/find/index.js
+++ b/routes/actions/find/index.js
@@ -1,10 +1,62 @@
 const express = require('express');
 const router = express.Router();
+const request = require('request');
 
 router.route('/').post((req, res) => {
   console.log("[POST] actions/find: ", req.body);
 
-  return res.status(200).json(req.body);
+  console.log(req.body.trigger_id);
+  console.log(req.body.token);
+
+  sendDialog(req.body.token,req.body.trigger_id)
+    .then(() => {
+      return res.status(200).json({ message:'Launching ASC Finder'});
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(200).json({ error: `Failed to launch ASC Finder ${err}`});
+    });
+
 });
+
+function sendDialog(token, trigger_id) {
+  return new Promise((resolve, reject) => {
+
+    var dialogDataJSON=JSON.stringify({
+      "trigger_id": trigger_id,
+      "dialog": {
+        "callback_id": "bmo-callbackid",
+        "title":"BMO Dialog",
+        "elements": [{
+          "type": "text",
+          "label": "Enter something",
+          "name": "enter"
+        }]
+      }
+    });
+
+    var token='xoxp-284151022912-682481769248-689859748852-ff15c6d4c7f61afc8649e398739ceb7b';
+    var postTo="https://slack.com/api/dialog.open";
+
+    console.log(postTo);
+
+    request.post({uri:postTo,
+                  auth: {bearer:token},
+                  body: dialogDataJSON,
+                  headers: {'Content-Type':'application/json; charset=\"utf-8\"'} },
+				   function(err,res, body) {
+
+					if (err) reject(err);
+          if (res.statusCode != 200) {
+              reject('Login Invalid status code <' + res.statusCode + '>');
+          }
+
+          if(!body.ok) reject(body);
+
+          resolve(body);
+	  });
+	});
+}
+
 
 module.exports = router;

--- a/routes/actions/find/index.js
+++ b/routes/actions/find/index.js
@@ -25,6 +25,7 @@ function sendDialog(token, trigger_id) {
 
     var dialogDataJSON=JSON.stringify({
       "trigger_id": trigger_id,
+      "response_url": config.get("app.find.responseURL"),
       "dialog": {
         "callback_id": "bmo-callbackid",
         "title":"BMO Dialog",
@@ -36,10 +37,10 @@ function sendDialog(token, trigger_id) {
       }
     });
 
-    var token=config.get("app.find.slackToken");
-    var postTo="https://slack.com/api/dialog.open";
+    console.dir(JSON.parse(dialogDataJSON));
 
-    console.log(postTo);
+    var token=config.get("app.find.slackToken");
+    var postTo=config.get("app.find.slackURL");
 
     request.post({uri:postTo,
                   auth: {bearer:token},
@@ -52,7 +53,9 @@ function sendDialog(token, trigger_id) {
               reject('Login Invalid status code <' + res.statusCode + '>');
           }
 
-          if(!body.ok) reject(body);
+          if(body!='{\"ok\":true}') {
+            reject(body);
+          } 
 
           resolve(body);
 	  });

--- a/routes/actions/find/index.js
+++ b/routes/actions/find/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const request = require('request');
+const config = require('../../../config/config');
 
 router.route('/').post((req, res) => {
   console.log("[POST] actions/find: ", req.body);
@@ -35,7 +36,7 @@ function sendDialog(token, trigger_id) {
       }
     });
 
-    var token='xoxp-284151022912-682481769248-689859748852-ff15c6d4c7f61afc8649e398739ceb7b';
+    var token=config.get("app.find.slackToken");
     var postTo="https://slack.com/api/dialog.open";
 
     console.log(postTo);

--- a/routes/actions/search/index.js
+++ b/routes/actions/search/index.js
@@ -43,7 +43,7 @@ router.route('/').post((req, res) => {
     console.log("WARNING - search - VerifySignature disabled");
   }
 
-  console.log("[POST] actions/search - body: ", req.body);
+//  console.log("[POST] actions/search - body: ", req.body);
 
   const VALID_COMMAND = '/asc-search';
 
@@ -174,10 +174,16 @@ function getToken() {
                   password: config.get('app.search.strapiPassword')} },
 				   function(err,res, body) {
 
-					if (err) reject(err);
-    		        if (res.statusCode != 200) {
-            		    reject('Login Invalid status code <' + res.statusCode + '>');
-            		}
+          if (err!=undefined) {
+            console.log('err login '+loginURL);
+            reject(err);
+             return;
+          };
+          if (res.statusCode != 200) {
+            console.log('!200 login '+loginURL);
+            reject('Login Invalid status code <' + res.statusCode + '>');
+              return;
+          }
           resolve(body.jwt);
 	  });
 	});
@@ -192,11 +198,13 @@ function searchType(token, queryURL, searchKey, value, responseMap) {
       if (err) {
           console.log('err POSTed '+searchURL);
           reject(err);
-      }
+          return;
+        }
     
       if (res.statusCode != 200) {
         console.log('!200 POSTed '+searchURL);
         reject('Invalid status code <' + res.statusCode + '>');
+        return;
       }
 
       var resArry=Array.from(body);

--- a/routes/actions/search/index.js
+++ b/routes/actions/search/index.js
@@ -246,18 +246,19 @@ function messageAsync(res, command, searchKey, searchValues, results, msgBuilder
     }),
   });
 
-  sendResults(msgBuilder.response_url, resultMsgJSON)
+  sendResults(msgBuilder.responseURL, resultMsgJSON)
       .catch((err) => { console.log("sendResults "+err)});
 }
 
-function sendResults(response_url, resultMsgJSON) {
+function sendResults(responseURL, resultMsgJSON) {
   return new Promise((resolve, reject) => {
 
     var token=config.get("app.find.slackToken");
 //    var postTo=config.get("app.find.slackURL");
 
-    request.post({uri:response_url,
-                  auth: {bearer:token},
+    console.log(responseURL);
+
+    request.post({uri:responseURL,
                   body: resultMsgJSON,
                   headers: {'Content-Type':'application/json; charset=\"utf-8\"'} },
 				   function(err,res, body) {
@@ -286,6 +287,7 @@ router.route('/callback').post((req, res) => {
 
   //console.log("POST find/callback " + req.body.payload);
   req.body=JSON.parse(req.body.payload);
+  console.log(req.body);
   console.log(req.body.submission);
 
   var msgBuilder={fn: messageAsync, async: true, responseURL: req.body.response_url};

--- a/routes/actions/search/index.js
+++ b/routes/actions/search/index.js
@@ -172,7 +172,7 @@ function getToken() {
 
 					if (err) reject(err);
     		        if (res.statusCode != 200) {
-            		    reject('Invalid status code <' + res.statusCode + '>');
+            		    reject('Login Invalid status code <' + res.statusCode + '>');
             		}
           resolve(body.jwt);
 	  });

--- a/routes/actions/search/index.js
+++ b/routes/actions/search/index.js
@@ -36,8 +36,12 @@ const establishmentMap=function(res) {return {establishmentName: res.Name, nmdsi
 const userMap=function(res) {return {name: res.FullNameValue, username: res.Username, establishmentId: res.EstablishmentID}}
 
 router.route('/').post((req, res) => {
-  // TODO - verifying 
-  // if (!isVerified(req)) return res.status(401).send();
+
+  if(config.get('app.search.verifySignature')) {
+    if (!isVerified(req)) return res.status(401).send();
+  } else {
+    console.log("WARNING - search - VerifySignature disabled");
+  }
 
   //console.log("[POST] actions/search - body: ", req.body);
 

--- a/routes/actions/search/index.js
+++ b/routes/actions/search/index.js
@@ -43,7 +43,7 @@ router.route('/').post((req, res) => {
     console.log("WARNING - search - VerifySignature disabled");
   }
 
-  //console.log("[POST] actions/search - body: ", req.body);
+  console.log("[POST] actions/search - body: ", req.body);
 
   const VALID_COMMAND = '/asc-search';
 

--- a/routes/interactions/index.js
+++ b/routes/interactions/index.js
@@ -62,7 +62,7 @@ const openDialog = async (payload, real_name) => {
 };
 
 router.route('/').post(async (req, res) => {
-  // console.log("[POST] interactions: ", req.body);
+ console.log("[POST] interactions: ", req.body);
 
   if (req.body.payload) {
     const payload = JSON.parse(req.body.payload);

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const bodyParser = require('body-parser');
 // const proxy = require('express-http-proxy');          // for service public/download content
 
+const querystring = require('querystring');
+
 // app config
 const AppConfig = require('./config/appConfig');
 const config = require('./config/config');
@@ -61,8 +63,30 @@ app.use('/', helmet({
  * end security
  */
 
+// for verifying signature
+//app.use('/actions',function(req, res, next){
+//    var data = "";
+//    req.on('data', function(chunk){
+//      data += chunk;
+//      next();
+//    })
+//    req.on('end', function(){
+//      req.rawBody = data;
+//      req.body=JSON.parse(data);
+//      next();
+//    })
+//});
+
+function getRaw(req, res, next) {
+    req.rawBody=req.body;
+    req.body=querystring.parse(req.rawBody);
+    next();
+}
+
 // for parsing of JSON from request body
 app.use(bodyParser.json());
+app.use(bodyParser.text({ type: 'application/x-www-form-urlencoded' }));
+app.use(getRaw);
 app.use(bodyParser.urlencoded({ extended: true }));
 
 // this middleware add common 'no cache' headerst to the response

--- a/server.js
+++ b/server.js
@@ -56,27 +56,6 @@ app.use('/', helmet({
     }
 }));
 
-// encodes all URL parameters
-// app.use('/', xssClean());
-// app.use('/', sanitizer());
-/*
- * end security
- */
-
-// for verifying signature
-//app.use('/actions',function(req, res, next){
-//    var data = "";
-//    req.on('data', function(chunk){
-//      data += chunk;
-//      next();
-//    })
-//    req.on('end', function(){
-//      req.rawBody = data;
-//      req.body=JSON.parse(data);
-//      next();
-//    })
-//});
-
 function getRaw(req, res, next) {
     req.rawBody=req.body;
     req.body=querystring.parse(req.rawBody);
@@ -85,8 +64,11 @@ function getRaw(req, res, next) {
 
 // for parsing of JSON from request body
 app.use(bodyParser.json());
+
+// Look out for our Slack 
 app.use(bodyParser.text({ type: 'application/x-www-form-urlencoded' }));
 app.use(getRaw);
+
 app.use(bodyParser.urlencoded({ extended: true }));
 
 // this middleware add common 'no cache' headerst to the response

--- a/utils/verifySignature.js
+++ b/utils/verifySignature.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const timingSafeCompare = require('tsscmp');
 
 const isVerified = (req) => { 
-console.log("WA DEBUG - slack secret: ", config.get('slack.secret'))
+  console.log("WA DEBUG - slack secret: ", config.get('slack.secret'))
 
   const signature = req.headers['x-slack-signature'];
   const timestamp = req.headers['x-slack-request-timestamp'];
@@ -18,6 +18,9 @@ console.log("WA DEBUG - slack secret: ", config.get('slack.secret'))
   console.log("WA DEBUG - got this far")
 
   hmac.update(`${version}:${timestamp}:${req.rawBody}`);
+
+//  console.log(hmac.digest('hex'));
+//  console.log(hash);
 
   // check that the request signature matches expected value
   const hashCheck = timingSafeCompare(hmac.digest('hex'), hash);


### PR DESCRIPTION
This PR includes successful demonstration of receiving /search and /find slash commands from Slack app.

It includes verifying inbound requests from Slack; rejecting request that fail hash signature (on both headers and body).

It includes calling back to Slack and presenting a find dialog box, the call to action (CTA) of which returns effectively invokes the /search endpoint.