### PR TITLE
Slack error response 200

### DIFF
--- a/utils/search.js
+++ b/utils/search.js
@@ -46,7 +46,7 @@ function getEstablishmentData(command, searchKey, searchValues, res, msgBuilder)
         console.log(err);
         if(!msgBuilder.async) {
           console.error('getEstablishmentData searchtype error:', err);
-          res.status(500).json({ error: `Strapi getEstablishmentData`});
+          res.status(200).json({ error: `Failed - No results found`});
         }
       });
   })
@@ -54,7 +54,7 @@ function getEstablishmentData(command, searchKey, searchValues, res, msgBuilder)
     console.log(err);
     if(!msgBuilder.async) {
       console.error('getEstablishmentData login error:', err);
-      res.status(200).json({ error: `Strapi login error`});
+      res.status(200).json({ error: `Authentication failed`});
     }
   });
 }
@@ -88,7 +88,7 @@ function getUserData(command, searchKey, searchValues, res, msgBuilder) {
               console.log(err);
               if(!msgBuilder.async) {
                 console.error('getUserData searchtype establishments error:', err);
-                res.status(500).json({ error: `Strapi getUserData establishments`});
+                res.status(200).json({ error: `Failed - No results found`});
               }
             });
           } else {
@@ -99,13 +99,13 @@ function getUserData(command, searchKey, searchValues, res, msgBuilder) {
         console.log(err);
         if(!msgBuilder.async) {
           console.error('getUserData searchtype error:', err);
-          res.status(500).json({ error: `Strapi getUserData searchtype`});
+          res.status(200).json({ error: `Failed - No results found`});
         }
       });
   })
   .catch((err) => {
     console.error('getUserData login error:', err);
-    res.status(200).json({ error: `Strapi login error`});
+    res.status(200).json({ error: `Authentication failed`});
   });
 }
 

--- a/utils/search.js
+++ b/utils/search.js
@@ -54,7 +54,7 @@ function getEstablishmentData(command, searchKey, searchValues, res, msgBuilder)
     console.log(err);
     if(!msgBuilder.async) {
       console.error('getEstablishmentData login error:', err);
-      res.status(500).json({ error: `Strapi getEstablishmentData`});
+      res.status(200).json({ error: `Strapi login error`});
     }
   });
 }
@@ -104,8 +104,8 @@ function getUserData(command, searchKey, searchValues, res, msgBuilder) {
       });
   })
   .catch((err) => {
-    console.error('getUserData error:', err);
-    res.status(500).json({ error: `Strapi getUserData`});
+    console.error('getUserData login error:', err);
+    res.status(200).json({ error: `Strapi login error`});
   });
 }
 
@@ -154,7 +154,7 @@ function getToken() {
                       if (res.statusCode != 200) {
                         console.log('!200 login '+loginURL);
                         reject('Login Invalid status code <' + res.statusCode + '>');
-                          return;
+                        return;
                       }
                       resolve(body.jwt);
                   }


### PR DESCRIPTION
Return bland responses to slack when authentication or search fails.

BUT return a http 200 with a failure message, rather than a 500 which shows in Slack with application failure advice.

https://trello.com/c/5QdHl34Q/332-slack-app-when-fails-to-login-to-strapi-due-to-password-change-errors-badly
